### PR TITLE
add missing styling in customcolor-advanced_style.css

### DIFF
--- a/customcolor-advanced_style.css
+++ b/customcolor-advanced_style.css
@@ -58,7 +58,9 @@ progress::-webkit-progress-value {
 .emby-tab-button:hover,
 .selectLabelFocused,
 .inputLabelFocused,
-.textareaLabelFocused {
+.textareaLabelFocused
+.buttonActive,
+.button-link {
   color: rgba(var(--accent)) !important;
 }
 

--- a/customcolor-advanced_style.css
+++ b/customcolor-advanced_style.css
@@ -58,7 +58,7 @@ progress::-webkit-progress-value {
 .emby-tab-button:hover,
 .selectLabelFocused,
 .inputLabelFocused,
-.textareaLabelFocused
+.textareaLabelFocused,
 .buttonActive,
 .button-link {
   color: rgba(var(--accent)) !important;


### PR DESCRIPTION
Add accent color styling to repeat and shuffle button on the music player and a link in the admin dashboard.

![image](https://user-images.githubusercontent.com/11861011/96354058-1a7acf80-10a0-11eb-8a2d-595456c33158.png)
![image](https://user-images.githubusercontent.com/11861011/96354057-164eb200-10a0-11eb-86f2-31d7e3f041f6.png)
