### PR TITLE
Updated reverse proxy instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,33 +85,14 @@ When using the Nginx Reverse proxy config from the [Jellyfin docs](https://jelly
 Because the config includes Content-Security-Policy which reduces risk of XSS, you need to add the URL from this repo and the fonts to the list of allowed external sources.
 
 In the nginx config you should change the
+
 ```
 add_header Content-Security-Policy ....
 ```
 to:
+
 ```
-add_header Content-Security-Policy "default-src https: data: blob:; style-src 'self' 'unsafe-inline' 
-https://ctalvio.github.io/Monochromic/default_style.css 
-https://ctalvio.github.io/Monochromic/sharp_style.css 
-https://ctalvio.github.io/Monochromic/jfblue_style.css 
-https://ctalvio.github.io/Monochromic/jfpurple_style.css 
-https://ctalvio.github.io/Monochromic/bottom-progress_style.css.css 
-https://ctalvio.github.io/Monochromic/customcolor_style.css 
-https://ctalvio.github.io/Monochromic/customcolor-advanced_style.css
-https://ctalvio.github.io/Monochromic/improve-performance_style.css
-https://fonts.googleapis.com/css2; 
-script-src 'self' 'unsafe-inline' 
-https://www.gstatic.com/cv/js/sender/v1/cast_sender.js 
-https://www.youtube.com/iframe_api https://s.ytimg.com 
-https://ctalvio.github.io/Monochromic/default_style.css 
-https://ctalvio.github.io/Monochromic/sharp_style.css 
-https://ctalvio.github.io/Monochromic/jfblue_style.css 
-https://ctalvio.github.io/Monochromic/jfpurple_style.css 
-https://ctalvio.github.io/Monochromic/bottom-progress_style.css
-https://ctalvio.github.io/Monochromic/customcolor-advanced_style.css 
-https://ctalvio.github.io/Monochromic/customcolor_style.css;
-https://ctalvio.github.io/Monochromic/improve-performance_style.css
-worker-src 'self' blob:; connect-src 'self'; object-src 'none'; frame-ancestors 'self'";
+add_header Content-Security-Policy "default-src https: data: blob:; style-src 'self' 'unsafe-inline' https://ctalvio.github.io/Monochromic/default_style.css https://ctalvio.github.io/Monochromic/jfblue_style.css https://ctalvio.github.io/Monochromic/jfpurple_style.css https://ctalvio.github.io/Monochromic/bottom-progress_style.css https://ctalvio.github.io/Monochromic/customcolor-advanced_style.css https://ctalvio.github.io/Monochromic/improve-performance_style.css https://fonts.googleapis.com/css2; script-src 'self' 'unsafe-inline' https://www.gstatic.com/cv/js/sender/v1/cast_sender.js worker-src 'self' blob:; connect-src 'self'; object-src 'none'; frame-ancestors 'self'";
 ```
 
 If you don't do this the theme will simply not load (reverts back to default theme) and the browser console will spit out an error. Even if you paste in all the CSS, the font will still not load since it is loaded from an external source.


### PR DESCRIPTION
The current instructions have URLs written across multiple newlines which causes browsers to incorrectly parse them. Furthermore, it is unnecessary to have CSS files whitelisted as scripts.