### PR TITLE
change favourite heart colour

### DIFF
--- a/default_style.css
+++ b/default_style.css
@@ -654,11 +654,14 @@ div[data-role=controlgroup] a[data-role=button]+a[data-role=button] {
   background: #101010 !important;
 }
 
+.ratingbutton-icon-withrating{
+  color: rgba(255, 0, 0, 0.6) !important;
+}
+
 .paper-icon-button-light:hover,
 .raised.homeLibraryButton:hover,
 .button-flat:hover,
 .playstatebutton-icon-played,
-.ratingbutton-icon-withrating,
 .paper-icon-button-light:hover:not(:disabled),
 .emby-tab-button:hover,
 .selectLabelFocused,


### PR DESCRIPTION
update heart icon color when an item is favorite so it is easier to view. It was vary hard to know if an item is favorite or not with a dark background, this changes the icon to red instead of dark grey. The red is a bit darker to fit with the rest of this amazing theme.

![image](https://user-images.githubusercontent.com/22400032/104102882-9c058680-52b8-11eb-8be7-9af585b5d373.png)
